### PR TITLE
fix(boot.sh): fix FLUENTD_CONF env var during boot

### DIFF
--- a/rootfs/fluentd/sbin/boot
+++ b/rootfs/fluentd/sbin/boot
@@ -1,5 +1,5 @@
 #!/bin/bash
-FLUENTD_CONF="/fluentd/etc/${FLUENTD_CONF}"
+FLUENTD_CONF="/fluentd/etc/fluentd.conf"
 INSTALL_BUILD_TOOLS=${INSTALL_BUILD_TOOLS:-"false"}
 BUILD_TOOLS='g++ gcc make ruby-dev'
 


### PR DESCRIPTION
Fixing the image boot.sh so that fluent.conf is initialized during container boot.