### PR TITLE
feat(fluentd): Allow option to only log router logs to elasticsearch

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --update --virtual .build-deps sudo build-base ruby-dev \
     &&  bundle install --gemfile=/fluentd/deis-output/Gemfile \
     &&  rake --rakefile=/fluentd/deis-output/Rakefile build \
     &&  fluent-gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 2.1.4 \
-    &&  fluent-gem install --no-document fluent-plugin-elasticsearch -v 2.12.0 \
+    &&  fluent-gem install --no-document fluent-plugin-elasticsearch -v 4.0.4 \
     &&  fluent-gem install --no-document fluent-plugin-remote_syslog -v 1.0.0 \
     &&  fluent-gem install --no-document fluent-plugin-sumologic-mattk42 -v 0.0.4 \
     &&  fluent-gem install --no-document fluent-plugin-gelf-hs -v 1.0.7 \

--- a/rootfs/fluentd/sbin/boot
+++ b/rootfs/fluentd/sbin/boot
@@ -36,6 +36,31 @@ cat << EOF >> $FLUENTD_CONF
 EOF
 fi
 
+# If you want to ONLY  log deis router logs to elasticsearch
+# then we Gclose the previous <match> tag and create a new one
+# just for matching deis-router logs. Output would be like:
+# <match kubernetes.var.log.containers.deis-router-**.log>
+#   @type copy
+# <store>
+#   @type elasticsearch
+#   ...
+# </store>
+# </match>
+if [ -n "${ELASTICSEARCH_DEIS_ROUTER_LOGS_ONLY}" ]
+then
+cat << EOF >> $FLUENTD_CONF
+<match kubernetes.var.log.containers.deis-router-**.log>
+  @type copy
+EOF
+
+source /fluentd/sbin/stores/elastic_search
+source /fluentd/sbin/stores/stores
+
+cat << EOF >> $FLUENTD_CONF
+</match>
+EOF
+fi
+
 cat << EOF >> $FLUENTD_CONF
 <match **>
   @type copy

--- a/rootfs/fluentd/sbin/stores/stores
+++ b/rootfs/fluentd/sbin/stores/stores
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source /fluentd/sbin/stores/deis
-source /fluentd/sbin/stores/elastic_search
+[ -z "${ELASTICSEARCH_DEIS_ROUTER_LOGS_ONLY}" ] && source /fluentd/sbin/stores/elastic_search
 source /fluentd/sbin/stores/syslog
 source /fluentd/sbin/stores/sumologic
 source /fluentd/sbin/stores/custom_stores


### PR DESCRIPTION
This allows to use elasticsearch output plugin to only parse and log deis router logs
We use this together with the following custom filter:

```
<filter kubernetes.var.log.containers.deis-router-**.log>
  @type parser
  key_name log
 reserve_data true
  <parse>
    @type regexp
    expression /^[^ ]* - (?<app_name>[^ ]*) - (?<remote_addr>[^ ]*) - (?<remote_user>[^ ]*) - (?<status_code>[^ ]*) - "(?<method>\S+[^\"])(?: +(?<path>[^\"]*?)(?: +\S*)?)?" - (?<bytes_sent>[^ ]*) - "(?<referer>[^ ]*)" - "(?<agent>[^\"]*)\" - \"(?<server_name>[^ ]*)" - (?<upstream_addr>[^ ]*) - (?<http_host>[^ ]*) - (?<upstream_response_time>[^ ]*) - (?<request_time>[^ ]*)$/
    time_format %d/%b/%Y:%H:%M:%S %z
  </parse>
</filter>
```

This filter basically gets the router logs and parses it into different fields so it can be filtered in elasticsearch.

This is our fluentd section of our deis workflow YAML settings using this code:
```yaml
fluentd:
  daemon_environment:
    org: "n0n0x"
    docker_tag: "v2.14.15-santi"
    ELASTICSEARCH_HOST: "elasticsearch.url.com"
    ELASTICSEARCH_SCHEME: "http"
    ELASTICSEARCH_PORT: "80"
    ELASTICSEARCH_DEIS_ROUTER_LOGS_ONLY: "True"
    CUSTOM_FILTER_1: "<filter kubernetes.var.log.containers.deis-router-**.log>\n  @type
      parser\n  key_name log\n reserve_data true\n  <parse>\n    @type regexp\n
      \   expression /^[^ ]* - (?<app_name>[^ ]*) - (?<remote_addr>[^ ]*) -
      (?<remote_user>[^ ]*) - (?<status_code>[^ ]*) - \"(?<method>\\S+[^\\\"])(?:
      +(?<path>[^\\\"]*?)(?: +\\S*)?)?\" - (?<bytes_sent>[^ ]*) - \"(?<referer>[^
      ]*)\" - \"(?<agent>[^\\\"]*)\\\" - \\\"(?<server_name>[^ ]*)\" - (?<upstream_addr>[^
      ]*) - (?<http_host>[^ ]*) - (?<upstream_response_time>[^ ]*) - (?<request_time>[^
      ]*)$/\n    time_format %d/%b/%Y:%H:%M:%S %z\n  </parse>\n</filter>"
```